### PR TITLE
Squashed commit of the following:

### DIFF
--- a/content/Flavours/Architecture/clean-architecture.md
+++ b/content/Flavours/Architecture/clean-architecture.md
@@ -1,6 +1,6 @@
 ---
 categories:
-  - architecture
+  - Architecture
 authors:
   - Yoan Thirion
 problems:

--- a/content/Flavours/Design/avoid-exceptions.md
+++ b/content/Flavours/Design/avoid-exceptions.md
@@ -1,6 +1,6 @@
 ---
 categories:
-  - design
+  - Design
 authors:
   - Yoan Thirion
 problems:

--- a/content/Flavours/Design/command-query-separation.md
+++ b/content/Flavours/Design/command-query-separation.md
@@ -1,6 +1,6 @@
 ---
 categories:
-  - design
+  - Design
 authors:
   - Guillaume Faas
 problems:

--- a/content/Flavours/Practices/example-mapping.md
+++ b/content/Flavours/Practices/example-mapping.md
@@ -1,6 +1,6 @@
 ---
 categories:
-  - Practice
+  - Practices
 authors:
   - Yoan Thirion
 problems:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,7 +84,15 @@ const config: Config = {
       additionalLanguages: ['csharp', 'java'],
     },
   } satisfies Preset.ThemeConfig,
-  plugins: ['docusaurus-lunr-search'],
+  plugins: [
+    'docusaurus-lunr-search',
+    [
+      'docusaurus-graph',
+      {
+        path: 'content',
+      },
+    ],
+  ],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/fontawesome-free": "^6.5.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-graph": "^1.0.3",
     "docusaurus-lunr-search": "^3.3.2",
     "font-awesome": "^4.7.0",
     "prism-react-renderer": "^2.3.0",

--- a/static/docusaurus-graph.json
+++ b/static/docusaurus-graph.json
@@ -1,0 +1,252 @@
+[
+  {
+    "id": "Architecture Decision Record",
+    "title": "Architecture Decision Record",
+    "linkTo": [],
+    "referencedBy": [
+      "Architecture"
+    ]
+  },
+  {
+    "id": "Architecture",
+    "title": "Architecture",
+    "linkTo": [
+      "Architecture Decision Record",
+      "Architecture Unit Tests",
+      "Clean Architecture",
+      "Software Architecture Document"
+    ],
+    "referencedBy": []
+  },
+  {
+    "id": "Architecture Unit Tests",
+    "title": "Architecture Unit Tests",
+    "linkTo": [],
+    "referencedBy": [
+      "Architecture"
+    ]
+  },
+  {
+    "id": "Clean Architecture",
+    "title": "Clean Architecture",
+    "linkTo": [],
+    "referencedBy": [
+      "Architecture"
+    ]
+  },
+  {
+    "id": "Software Architecture Document",
+    "title": "Software Architecture Document",
+    "linkTo": [],
+    "referencedBy": [
+      "Architecture"
+    ]
+  },
+  {
+    "id": "Avoid Exceptions",
+    "title": "Avoid Exceptions",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Design",
+    "title": "Design",
+    "linkTo": [
+      "Avoid Exceptions",
+      "Command Query Separation",
+      "Factory Pattern",
+      "Generate Code From Usage",
+      "Immutable Types",
+      "Monads",
+      "No For Loops",
+      "No primitive types",
+      "Parse, don't Validate",
+      "Pure Functions",
+      "Tell Don't Ask",
+      "Fluent Assertions",
+      "Property-Based Testing"
+    ],
+    "referencedBy": []
+  },
+  {
+    "id": "Command Query Separation",
+    "title": "Command Query Separation",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Factory Pattern",
+    "title": "Factory Pattern",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Generate Code From Usage",
+    "title": "Generate Code From Usage",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Immutable Types",
+    "title": "Immutable Types",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Monads",
+    "title": "Monads",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "No For Loops",
+    "title": "No For Loops",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "No primitive types",
+    "title": "No primitive types",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Parse, don't Validate",
+    "title": "Parse, don't Validate",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Pure Functions",
+    "title": "Pure Functions",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Tell Don't Ask",
+    "title": "Tell Don't Ask",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Example Mapping",
+    "title": "Example Mapping",
+    "linkTo": [],
+    "referencedBy": [
+      "Practices"
+    ]
+  },
+  {
+    "id": "Practices",
+    "title": "Practices",
+    "linkTo": [
+      "Example Mapping",
+      "Keep Dependencies Up-to-Date",
+      "Treat Warnings as Errors"
+    ],
+    "referencedBy": []
+  },
+  {
+    "id": "Keep Dependencies Up-to-Date",
+    "title": "Keep Dependencies Up-to-Date",
+    "linkTo": [],
+    "referencedBy": [
+      "Practices"
+    ]
+  },
+  {
+    "id": "Treat Warnings as Errors",
+    "title": "Treat Warnings as Errors",
+    "linkTo": [],
+    "referencedBy": [
+      "Practices"
+    ]
+  },
+  {
+    "id": "Strangler Pattern",
+    "title": "Strangler Pattern",
+    "linkTo": [],
+    "referencedBy": [
+      "Refactoring"
+    ]
+  },
+  {
+    "id": "Refactoring",
+    "title": "Refactoring",
+    "linkTo": [
+      "Strangler Pattern"
+    ],
+    "referencedBy": []
+  },
+  {
+    "id": "Fluent Assertions",
+    "title": "Fluent Assertions",
+    "linkTo": [],
+    "referencedBy": [
+      "Design"
+    ]
+  },
+  {
+    "id": "Mutation Testing",
+    "title": "Mutation Testing",
+    "linkTo": [],
+    "referencedBy": [
+      "Testing"
+    ]
+  },
+  {
+    "id": "Testing",
+    "title": "Testing",
+    "linkTo": [
+      "Mutation Testing",
+      "Property-Based Testing",
+      "Test Data Builders"
+    ],
+    "referencedBy": []
+  },
+  {
+    "id": "Property-Based Testing",
+    "title": "Property-Based Testing",
+    "linkTo": [],
+    "referencedBy": [
+      "Design",
+      "Testing"
+    ]
+  },
+  {
+    "id": "Test Data Builders",
+    "title": "Test Data Builders",
+    "linkTo": [],
+    "referencedBy": [
+      "Testing"
+    ]
+  },
+  {
+    "id": "Cards",
+    "title": "Cards",
+    "linkTo": [],
+    "referencedBy": []
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,6 +3637,14 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-graph@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/docusaurus-graph/-/docusaurus-graph-1.0.3.tgz#116ff4f3f0d920cf8e73ecc69301d7d9edde69b2"
+  integrity sha512-i2ahjV3jtNAJCVoYKS2YmxKRwZzM1ssQ0coRd+sWJSiXUgdvvlOzShysoVpKZxT1STwarK32kPXvmmxf8ILlUg==
+  dependencies:
+    gray-matter "^4.0.3"
+    marked "^12.0.2"
+
 docusaurus-lunr-search@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/docusaurus-lunr-search/-/docusaurus-lunr-search-3.3.2.tgz#23699b899d9275402e3004e1fe6085e1bae4f007"
@@ -5463,6 +5471,11 @@ markdown-table@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
+
+marked@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-12.0.2.tgz#b31578fe608b599944c69807b00f18edab84647e"
+  integrity sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==
 
 mdast-util-directive@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description
This pull request introduces a new plugin for our Docusaurus site that generates a graph view from the documentation files. The GraphView Plugin provides an interactive and visual representation of the relationships between different documents, enhancing navigation and understanding. This GraphView was available in the Gatsby site.

## Changes
- **Plugin Integration**:
  - Added the `docusaurus-graph` plugin to the project.
  - Configured the plugin in `docusaurus.config.ts`.
  - Specified the documentation folder to be scanned by the plugin (`path: 'content'`).
  - Updated Markdown files to ensure compatibility with the plugin.
- **Post Build Data File**:
  - The plugin generates a `docusaurus-graph.json` file in the build directory after the Docusaurus build process completes. This file contains the necessary data for the graph view, including nodes and edges.
  - The `docusaurus-graph.json` file is added to the `static` folder to be used in development mode. This ensures that the graph data is readily accessible and can be utilized during development for testing and visualization purposes.

## Type of change
Please check options that are relevants.

- [ ] New content
- [x] Website changes (fix or new feature)
- [x] This change requires a documentation update (refactor names)

## Checklist:
Please check options that are relevants.

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have contributed on the `trello` board as well

@HunteRoi 
